### PR TITLE
remove redis

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,10 +14,6 @@ declare class Analytics {
      */
     constructor(writeKey: string, dataPlaneURL: string, options?: any | undefined);
     queue: any[];
-    pQueue: any;
-    pQueueInitialized: boolean;
-    pQueueOpts: {};
-    pJobOpts: {};
     state: string;
     writeKey: string;
     host: string;
@@ -28,51 +24,6 @@ declare class Analytics {
     logLevel: any;
     flushed: boolean;
     logger: winston.Logger;
-    addPersistentQueueProcessor(): void;
-    /**
-     *
-     * @param {Object} queueOpts
-     * @param {String=} queueOpts.queueName
-     * @param {String=} queueOpts.prefix
-     * @param {Boolean=} queueOpts.isMultiProcessor
-     * @param {Object} queueOpts.redisOpts
-     * @param {Number=} queueOpts.redisOpts.port
-     * @param {String=} queueOpts.redisOpts.host
-     * @param {Number=} queueOpts.redisOpts.db
-     * @param {String=} queueOpts.redisOpts.password
-     * @param {Object=} queueOpts.jobOpts
-     * @param {Number} queueOpts.jobOpts.maxAttempts
-     * {
-     *    queueName: string = rudderEventsQueue,
-     *    prefix: string = rudder
-     *    isMultiProcessor: booloean = false
-     *    redisOpts: {
-     *      port?: number = 6379;
-     *      host?: string = localhost;
-     *      db?: number = 0;
-     *      password?: string;
-     *    },
-     *    jobOpts: {
-     *      maxAttempts: number = 10
-     *    }
-     * }
-     * @param {*} callback
-     *  All error paths from redis and queue will give exception, so they are non-retryable from SDK perspective
-     *  The queue may not function for unhandled promise rejections
-     *  this error callback is called when the SDK wants the user to retry
-     */
-    createPersistenceQueue(queueOpts: {
-        queueName?: string | undefined;
-        prefix?: string | undefined;
-        isMultiProcessor?: boolean | undefined;
-        redisOpts: {
-            port?: number | undefined;
-            host?: string | undefined;
-            db?: number | undefined;
-            password?: string | undefined;
-        };
-        jobOpts?: any | undefined;
-    }, callback: any): void;
     _validate(message: any, type: any): void;
     /**
      * Send an identify `message`.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const assert = require("assert");
 const removeSlash = require("remove-trailing-slash");
 const looselyValidate = require("@segment/loosely-validate-event");
 const serialize = require("serialize-javascript");
-const Queue = require("bull");
 const axios = require("axios");
 const axiosRetry = require("axios-retry");
 const ms = require("ms");
@@ -41,10 +40,6 @@ class Analytics {
     assert(dataPlaneURL, "You must pass your data plane url.");
 
     this.queue = [];
-    this.pQueue = undefined;
-    this.pQueueInitialized = false;
-    this.pQueueOpts = undefined;
-    this.pJobOpts = {};
     this.state = "idle";
     this.writeKey = writeKey;
     this.host = removeSlash(dataPlaneURL);
@@ -72,231 +67,6 @@ class Analytics {
     });
 
     axiosRetry(axios, { retries: 0 });
-  }
-
-  addPersistentQueueProcessor() {
-    const _isErrorRetryable = this._isErrorRetryable.bind(this);
-    const rdone = (callbacks, err) => {
-      callbacks.forEach((callback_) => {
-        callback_(err);
-      });
-    };
-
-    const payloadQueue = this.pQueue;
-    const jobOpts = this.pJobOpts;
-
-    this.pQueue.on("failed", function(job, error) {
-      let jobData = eval("(" + job.data.eventData + ")");
-      this.logger.error("job : " + jobData.description + " " + error);
-    });
-
-    // tapping on queue events
-    this.pQueue.on("completed", function(job, result) {
-      let jobData = eval("(" + job.data.eventData + ")");
-      result = result || "completed";
-      this.logger.debug("job : " + jobData.description + " " + result);
-    });
-
-    this.pQueue.on("stalled", function(job) {
-      let jobData = eval("(" + job.data.eventData + ")");
-      this.logger.warn("job : " + jobData.description + " is stalled...");
-    });
-
-    this.pQueue.process(function(job, done) {
-      // job failed for maxAttempts or more times, push to failed queue
-      // starting with attempt = 0
-      let maxAttempts = jobOpts.maxAttempts || 10;
-      let jobData = eval("(" + job.data.eventData + ")");
-      if (jobData.attempts >= maxAttempts) {
-        done(
-          new Error(
-            "job : " +
-              jobData.description +
-              " pushed to failed queue after attempts " +
-              jobData.attempts +
-              " skipping further retries..."
-          )
-        );
-      } else {
-        // process the job after exponential delay, if it's the 0th attempt, setTimeout will fire immediately
-        // max delay is 30 sec, it is mostly in sync with a bull queue job max lock time
-        setTimeout(function() {
-          let req = jobData.request;
-          req.data.sentAt = new Date();
-          // if request succeeded, mark the job done and move to completed
-          axios(req)
-            .then((response) => {
-              rdone(jobData.callbacks);
-              done();
-            })
-            .catch((err) => {
-              // check if request is retryable
-              if (_isErrorRetryable(err)) {
-                let attempts = jobData.attempts;
-                jobData.attempts = attempts + 1;
-                // increment attempt
-                // add a new job to queue in lifo
-                // if able to add, mark the earlier job done with push to completed with a msg
-                // if add to redis queue gives exception, not catching it
-                // in case of redis queue error, mark the job as failed ? i.e add the catch block in below promise ?
-                payloadQueue
-                  .add({ eventData: serialize(jobData) }, { lifo: true })
-                  .then((pushedJob) => {
-                    done(
-                      null,
-                      "job : " +
-                        jobData.description +
-                        " failed for attempt " +
-                        attempts +
-                        " " +
-                        err
-                    );
-                  })
-                  .catch((error) => {
-                    this.logger.error("failed to requeue job " + jobData.description);
-                    rdone(jobData.callbacks, error);
-                    done(error);
-                  });
-              } else {
-                // if not retryable, mark the job failed and to failed queue for user to retry later
-                rdone(jobData.callbacks, err);
-                done(err);
-              }
-            });
-        }, Math.min(30000, Math.pow(2, jobData.attempts) * 1000));
-      }
-    });
-  }
-
-  /**
-   *
-   * @param {Object} queueOpts
-   * @param {String=} queueOpts.queueName
-   * @param {String=} queueOpts.prefix
-   * @param {Boolean=} queueOpts.isMultiProcessor
-   * @param {Object} queueOpts.redisOpts
-   * @param {Number=} queueOpts.redisOpts.port
-   * @param {String=} queueOpts.redisOpts.host
-   * @param {Number=} queueOpts.redisOpts.db
-   * @param {String=} queueOpts.redisOpts.password
-   * @param {Object=} queueOpts.jobOpts
-   * @param {Number} queueOpts.jobOpts.maxAttempts
-   * {
-   *    queueName: string = rudderEventsQueue,
-   *    prefix: string = rudder
-   *    isMultiProcessor: booloean = false
-   *    redisOpts: {
-   *      port?: number = 6379;
-   *      host?: string = localhost;
-   *      db?: number = 0;
-   *      password?: string;
-   *    },
-   *    jobOpts: {
-   *      maxAttempts: number = 10
-   *    }
-   * }
-   * @param {*} callback
-   *  All error paths from redis and queue will give exception, so they are non-retryable from SDK perspective
-   *  The queue may not function for unhandled promise rejections
-   *  this error callback is called when the SDK wants the user to retry
-   */
-  createPersistenceQueue(queueOpts, callback) {
-    if (this.pQueueInitialized) {
-      this.logger.debug("a persistent queue is already initialized, skipping...");
-      return;
-    }
-
-    this.pQueueOpts = queueOpts || {};
-    this.pQueueOpts.isMultiProcessor =
-      this.pQueueOpts.isMultiProcessor || false;
-    if (!this.pQueueOpts.redisOpts) {
-      throw new Error(
-        "redis connection parameters not present. Cannot make a persistent queue"
-      );
-    }
-    this.pJobOpts = this.pQueueOpts.jobOpts || {};
-    this.pQueue = new Queue(this.pQueueOpts.queueName || "rudderEventsQueue", {
-      redis: this.pQueueOpts.redisOpts,
-      prefix: "{" + this.pQueueOpts.prefix + "}" || "{rudder}",
-    });
-
-    this.logger.debug("isMultiProcessor: " + this.pQueueOpts.isMultiProcessor);
-
-    this.pQueue
-      .isReady()
-      .then(() => {
-        // at startup get active job, remove it, then add it in front of queue to retried first
-        // then add the queue processor
-        // if queue is isMultiProcessor, skip the above and add the queue processor
-        if (this.pQueueOpts.isMultiProcessor) {
-          this.addPersistentQueueProcessor();
-          this.pQueueInitialized = true;
-          callback();
-        } else {
-          this.pQueue
-            .getActive()
-            .then((jobs) => {
-              this.logger.debug("success geting active jobs");
-              if (jobs.length == 0) {
-                this.logger.debug("there are no active jobs while starting up queue");
-                this.addPersistentQueueProcessor();
-                this.logger.debug("success adding process");
-                this.pQueueInitialized = true;
-                callback();
-              } else {
-                // since there is only once process, the count of active jobs will be 1 at max
-                // moving active job is important as this job doesn't have a process function
-                // and will later be retried which will mess event ordering
-                if (jobs.length > 1) {
-                  this.logger.debug(
-                    "number of active jobs at starting up queue > 1 "
-                  );
-                  callback(
-                    new Error(
-                      "queue has more than 1 active job, move them to failed and try again"
-                    )
-                  );
-                  return;
-                }
-                this.logger.debug(
-                  "number of active jobs at starting up queue = " + jobs.length
-                );
-                jobs.forEach((job) => {
-                  job
-                    .remove()
-                    .then(() => {
-                      this.logger.debug("success removed active job");
-                      let jobData = eval("(" + job.data.eventData + ")");
-                      jobData.attempts = 0;
-                      this.pQueue
-                        .add({ eventData: serialize(jobData) }, { lifo: true })
-                        .then((removedJob) => {
-                          this.logger.debug(
-                            "success adding removed job back to queue"
-                          );
-                          this.addPersistentQueueProcessor();
-                          this.logger.debug("success adding process");
-                          this.pQueueInitialized = true;
-                          callback();
-                        });
-                    })
-                    .catch((error) => {
-                      this.logger.error("failed to remove active job");
-                      callback(error);
-                    });
-                });
-              }
-            })
-            .catch((error) => {
-              this.logger.error("failed geting active jobs");
-              callback(error);
-            });
-        }
-      })
-      .catch((error) => {
-        this.logger.error("queue not ready");
-        callback(error);
-      });
   }
 
   _validate(message, type) {
@@ -612,64 +382,35 @@ class Analytics {
         typeof this.timeout === "string" ? ms(this.timeout) : this.timeout;
     }
 
-    if (this.pQueue && this.pQueueInitialized) {
-      let eventData = {
-        description: `node-${md5(JSON.stringify(req))}-${uuid()}`,
-        request: req,
-        callbacks: callbacks,
-        attempts: 0,
-      };
-      // using serialize library as default JSON.stringify mangles with function/callback serialization
-      this.pQueue
-        .add({ eventData: serialize(eventData) })
-        .then((pushedJob) => {
-          this.logger.debug("pushed job to queue");
-          this.queue.splice(0, items.length);
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.state = "idle";
-        })
-        .catch((error) => {
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.state = "idle";
-          this.logger.error(
-            "failed to push to redis queue, in-memory queue size: " +
-              this.queue.length
-          );
-          throw error;
-        });
-    } else if (!this.pQueue) {
-      axios({
-        ...req,
-        "axios-retry": {
-          retries: 3,
-          retryCondition: this._isErrorRetryable.bind(this),
-          retryDelay: axiosRetry.exponentialDelay
-        }
+    axios({
+      ...req,
+      "axios-retry": {
+        retries: 3,
+        retryCondition: this._isErrorRetryable.bind(this),
+        retryDelay: axiosRetry.exponentialDelay
+      }
+    })
+      .then((response) => {
+        this.queue.splice(0, items.length);
+        this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
+        this.state = "idle";
+        done();
       })
-        .then((response) => {
-          this.queue.splice(0, items.length);
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.state = "idle";
-          done();
-        })
-        .catch((err) => {
-          this.logger.error(
-            "got error while attempting send for 3 times, dropping " +
-              items.length +
-              " events"
-          );
-          this.queue.splice(0, items.length);
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.state = "idle";
-          if (err.response) {
-            const error = new Error(err.response.statusText);
-            return done(error);
-          }
-          done(err);
-        });
-    } else {
-      throw new Error("persistent queue not ready");
-    }
+      .catch((err) => {
+        this.logger.error(
+          "got error while attempting send for 3 times, dropping " +
+            items.length +
+            " events"
+        );
+        this.queue.splice(0, items.length);
+        this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
+        this.state = "idle";
+        if (err.response) {
+          const error = new Error(err.response.statusText);
+          return done(error);
+        }
+        done(err);
+      });
   }
 
   _isErrorRetryable(error) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@segment/loosely-validate-event": "^2.0.0",
     "axios": "^0.21.1",
     "axios-retry": "^3.0.2",
-    "bull": "^3.20.0",
     "lodash.isstring": "^4.0.1",
     "md5": "^2.2.1",
     "ms": "^2.0.0",


### PR DESCRIPTION
# Why
We'd like to slim down the package. so we'll be removing the unused Redis queue.

# How
Removed the `pQueue` (persistence queue) and all references to it. Uninstalled `bull`.

# Test Plan
I sent some requests using this version of the library and confirmed the events ended up at the correct destination.