### PR TITLE
[lint] Reformat files w/Prettier (zero lint warnings); disable CI tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/index.d.ts
+/index.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['universe/node']
+  extends: ['universe/node'],
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile
-      - run: yarn test
+      # - run: yarn test
       - run: yarn lint --max-warnings 0
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/cli.js
+++ b/cli.js
@@ -1,52 +1,35 @@
 #!/usr/bin/env node
 
-const program = require("commander");
-const Analytics = require(".");
-const pkg = require("./package");
+const program = require('commander');
 
-const toObject = str => JSON.parse(str);
+const Analytics = require('.');
+const pkg = require('./package');
+
+const toObject = (str) => JSON.parse(str);
 
 // node cli.js -w "write-key" -h "http://localhost" -t "identify" -u 'id
 program
   .version(pkg.version)
-  .option("-w, --writeKey <key>", "the write key to use")
-  .option("-h, --host <host>", "the API hostname to use")
-  .option("-t, --type <type>", "the message type")
+  .option('-w, --writeKey <key>', 'the write key to use')
+  .option('-h, --host <host>', 'the API hostname to use')
+  .option('-t, --type <type>', 'the message type')
 
-  .option("-u, --userId <id>", "the user id to send the event as")
+  .option('-u, --userId <id>', 'the user id to send the event as')
+  .option('-a, --anonymousId <id>', 'the anonymous user id to send the event as')
+  .option('-c, --context <context>', 'additional context for the event (JSON-encoded)', toObject)
   .option(
-    "-a, --anonymousId <id>",
-    "the anonymous user id to send the event as"
-  )
-  .option(
-    "-c, --context <context>",
-    "additional context for the event (JSON-encoded)",
-    toObject
-  )
-  .option(
-    "-i, --integrations <integrations>",
-    "additional integrations for the event (JSON-encoded)",
+    '-i, --integrations <integrations>',
+    'additional integrations for the event (JSON-encoded)',
     toObject
   )
 
-  .option("-e, --event <event>", "the event name to send with the event")
-  .option(
-    "-p, --properties <properties>",
-    "the event properties to send (JSON-encoded)",
-    toObject
-  )
+  .option('-e, --event <event>', 'the event name to send with the event')
+  .option('-p, --properties <properties>', 'the event properties to send (JSON-encoded)', toObject)
 
-  .option(
-    "-n, --name <name>",
-    "name of the screen or page to send with the message"
-  )
-  .option(
-    "-t, --traits <traits>",
-    "the identify/group traits to send (JSON-encoded)",
-    toObject
-  )
-  .option("-g, --groupId <groupId>", "the group id")
-  .option("-pid, --previousId <previousId>", "the previous id")
+  .option('-n, --name <name>', 'name of the screen or page to send with the message')
+  .option('-t, --traits <traits>', 'the identify/group traits to send (JSON-encoded)', toObject)
+  .option('-g, --groupId <groupId>', 'the group id')
+  .option('-pid, --previousId <previousId>', 'the previous id')
 
   .parse(process.argv);
 
@@ -72,7 +55,7 @@ const previousId = program.previousId;
 
 const run = (method, args) => {
   const analytics = new Analytics(writeKey, host, { flushAt: 1 });
-  analytics[method](args, err => {
+  analytics[method](args, (err) => {
     if (err) {
       console.error(err.stack);
       process.exit(1);
@@ -81,65 +64,65 @@ const run = (method, args) => {
 };
 
 switch (type) {
-  case "track":
-    run("track", {
+  case 'track':
+    run('track', {
       event,
       properties,
       userId,
       anonymousId,
       context,
-      integrations
+      integrations,
     });
     break;
-  case "page":
-    run("page", {
+  case 'page':
+    run('page', {
       name,
       properties,
       userId,
       anonymousId,
       context,
-      integrations
+      integrations,
     });
     break;
-  case "screen":
-    run("screen", {
+  case 'screen':
+    run('screen', {
       name,
       properties,
       userId,
       anonymousId,
       context,
-      integrations
+      integrations,
     });
     break;
-  case "identify":
-    run("identify", {
+  case 'identify':
+    run('identify', {
       traits,
       userId,
       anonymousId,
       context,
-      integrations
+      integrations,
     });
     break;
-  case "group":
-    run("group", {
+  case 'group':
+    run('group', {
       groupId,
       traits,
       userId,
       anonymousId,
       context,
-      integrations
+      integrations,
     });
     break;
-  case "alias":
-    run("alias", {
+  case 'alias':
+    run('alias', {
       previousId,
       userId,
       anonymousId,
       context,
-      integrations
+      integrations,
     });
     break;
   default:
-    console.error("invalid type:", type);
+    console.error('invalid type:', type);
     process.exit(1);
 }

--- a/index.ts
+++ b/index.ts
@@ -241,7 +241,7 @@ class Analytics {
       return;
     }
 
-    if (type == 'identify') {
+    if (type === 'identify') {
       if (message.traits) {
         if (!message.context) {
           message.context = {};
@@ -317,7 +317,7 @@ class Analytics {
   flush(callback?) {
     // check if earlier flush was pushed to queue
     this.logger.debug('in flush');
-    if (this.state == AnalyticsState.Running) {
+    if (this.state === AnalyticsState.Running) {
       this.logger.debug('skipping flush, earlier flush in progress');
       return;
     }

--- a/test.js
+++ b/test.js
@@ -1,62 +1,63 @@
-import { spy, stub } from "sinon";
-import bodyParser from "body-parser";
-import express from "express";
-import delay from "delay";
-import auth from "basic-auth";
-import pify from "pify";
-import test from "ava";
-import Analytics from ".";
-import { version } from "./package.json";
+import test from 'ava';
+import auth from 'basic-auth';
+import bodyParser from 'body-parser';
+import delay from 'delay';
+import express from 'express';
+import pify from 'pify';
+import { spy, stub } from 'sinon';
+
+import Analytics from '.';
+import { version } from './package.json';
 
 const noop = () => {};
 
 const context = {
   library: {
-    name: "@expo/rudder-node-sdk",
-    version
-  }
+    name: '@expo/rudder-node-sdk',
+    version,
+  },
 };
 
 const metadata = { nodeVersion: process.versions.node };
 const port = 4063;
 
-const createClient = options => {
+const createClient = (options) => {
   options = { ...options };
 
-  const client = new Analytics("key", `http://localhost:${port}`, options);
+  const client = new Analytics('key', `http://localhost:${port}`, options);
   client.flush = pify(client.flush.bind(client));
   client.flushed = true;
 
   return client;
 };
 
-test.before.cb(t => {
+test.before.cb((t) => {
   express()
     .use(bodyParser.json())
-    .post("/", (req, res) => {
+    .post('/', (req, res) => {
       const batch = req.body.batch;
 
       const { name: writeKey } = auth(req);
       if (!writeKey) {
         return res.status(400).json({
-          error: { message: "missing write key" }
+          error: { message: 'missing write key' },
         });
       }
 
-      const ua = req.headers["user-agent"];
+      const ua = req.headers['user-agent'];
       if (ua !== `analytics-node/${version}`) {
         return res.status(400).json({
-          error: { message: "invalid user-agent" }
+          error: { message: 'invalid user-agent' },
         });
       }
 
-      if (batch[0] === "error") {
+      if (batch[0] === 'error') {
         return res.status(400).json({
-          error: { message: "error" }
+          error: { message: 'error' },
         });
       }
 
-      if (batch[0] === "timeout") {
+      if (batch[0] === 'timeout') {
         return setTimeout(() => res.end(), 5000);
       }
 
@@ -66,81 +67,81 @@ test.before.cb(t => {
     .listen(port, t.end);
 });
 
-test("expose a constructor", t => {
-  t.is(typeof Analytics, "function");
+test('expose a constructor', (t) => {
+  t.is(typeof Analytics, 'function');
 });
 
-test("require a write key", t => {
+test('require a write key', (t) => {
   t.throws(() => new Analytics(), "You must pass your project's write key.");
 });
 
-test("create a queue", t => {
+test('create a queue', (t) => {
   const client = createClient();
 
   t.deepEqual(client.queue, []);
 });
 
-test("default options", t => {
-  t.throws(() => new Analytics("key"), "You must pass your data plane URL.");
+test('default options', (t) => {
+  t.throws(() => new Analytics('key'), 'You must pass your data plane URL.');
 });
 
-test("remove trailing slashes from `host`", t => {
-  const client = new Analytics("key", "http://google.com///");
+test('remove trailing slashes from `host`', (t) => {
+  const client = new Analytics('key', 'http://google.com///');
 
-  t.is(client.host, "http://google.com");
-  t.is(client.writeKey, "key");
+  t.is(client.host, 'http://google.com');
+  t.is(client.writeKey, 'key');
   t.is(client.flushAt, 20);
   t.is(client.flushInterval, 20000);
 });
 
-test("overwrite defaults with options", t => {
-  const client = new Analytics("key", "a", {
+test('overwrite defaults with options', (t) => {
+  const client = new Analytics('key', 'a', {
     flushAt: 1,
-    flushInterval: 2
+    flushInterval: 2,
   });
 
-  t.is(client.host, "a");
+  t.is(client.host, 'a');
   t.is(client.flushAt, 1);
   t.is(client.flushInterval, 2);
 });
 
-test("keep the flushAt option above zero", t => {
+test('keep the flushAt option above zero', (t) => {
   const client = createClient({ flushAt: 0 });
 
   t.is(client.flushAt, 1);
 });
 
-test("enqueue - add a message to the queue", t => {
+test('enqueue - add a message to the queue', (t) => {
   const client = createClient();
 
   const originalTimestamp = new Date();
-  client.enqueue("type", { originalTimestamp }, noop);
+  client.enqueue('type', { originalTimestamp }, noop);
 
   t.is(client.queue.length, 1);
 
   const item = client.queue.pop();
 
-  t.is(typeof item.message.messageId, "string");
+  t.is(typeof item.message.messageId, 'string');
   t.regex(item.message.messageId, /node-[a-zA-Z0-9]{32}/);
   t.deepEqual(item, {
     message: {
       originalTimestamp,
-      type: "type",
+      type: 'type',
       context,
       _metadata: metadata,
-      messageId: item.message.messageId
+      messageId: item.message.messageId,
     },
-    callback: noop
+    callback: noop,
   });
 });
 
-test("enqueue - stringify userId", t => {
+test('enqueue - stringify userId', (t) => {
   const client = createClient();
 
   client.track(
     {
       userId: 10,
-      event: "event"
+      event: 'event',
     },
     noop
   );
@@ -150,16 +151,16 @@ test("enqueue - stringify userId", t => {
   const item = client.queue.pop();
 
   t.is(item.message.anonymousId, undefined);
-  t.is(item.message.userId, "10");
+  t.is(item.message.userId, '10');
 });
 
-test("enqueue - stringify anonymousId", t => {
+test('enqueue - stringify anonymousId', (t) => {
   const client = createClient();
 
   client.screen(
     {
       anonymousId: 157963456373623802,
-      name: "screen name"
+      name: 'screen name',
     },
     noop
   );
@@ -170,19 +171,19 @@ test("enqueue - stringify anonymousId", t => {
 
   t.is(item.message.userId, undefined);
   // v8 will lose precision for big numbers.
-  t.is(item.message.anonymousId, "157963456373623800");
+  t.is(item.message.anonymousId, '157963456373623800');
 });
 
-test("enqueue - stringify ids handles strings", t => {
+test('enqueue - stringify ids handles strings', (t) => {
   const client = createClient();
 
   client.screen(
     {
-      anonymousId: "15796345",
+      anonymousId: '15796345',
       // We're explicitly testing the behaviour of the library if a customer
       // uses a String constructor.
-      userId: new String("prateek"), // eslint-disable-line no-new-wrappers
-      name: "screen name"
+      userId: new String('prateek'), // eslint-disable-line no-new-wrappers
+      name: 'screen name',
     },
     noop
   );
@@ -191,52 +192,52 @@ test("enqueue - stringify ids handles strings", t => {
 
   const item = client.queue.pop();
 
-  t.is(item.message.anonymousId, "15796345");
-  t.is(item.message.userId.toString(), "prateek");
+  t.is(item.message.anonymousId, '15796345');
+  t.is(item.message.userId.toString(), 'prateek');
 });
 
-test("enqueue - don't modify the original message", t => {
+test("enqueue - don't modify the original message", (t) => {
   const client = createClient();
-  const message = { event: "test" };
+  const message = { event: 'test' };
 
-  client.enqueue("type", message);
+  client.enqueue('type', message);
 
-  t.deepEqual(message, { event: "test" });
+  t.deepEqual(message, { event: 'test' });
 });
 
-test("enqueue - flush on first message", t => {
+test('enqueue - flush on first message', (t) => {
   const client = createClient({ flushAt: 2 });
   client.flushed = false;
-  spy(client, "flush");
+  spy(client, 'flush');
 
-  client.enqueue("type", {});
+  client.enqueue('type', {});
   t.true(client.flush.calledOnce);
 
-  client.enqueue("type", {});
+  client.enqueue('type', {});
   t.true(client.flush.calledOnce);
 
-  client.enqueue("type", {});
+  client.enqueue('type', {});
   t.true(client.flush.calledTwice);
 });
 
-test("enqueue - flush the queue if it hits the max length", t => {
+test('enqueue - flush the queue if it hits the max length', (t) => {
   const client = createClient({
     flushAt: 1,
-    flushInterval: null
+    flushInterval: null,
   });
 
-  stub(client, "flush");
+  stub(client, 'flush');
 
-  client.enqueue("type", {});
+  client.enqueue('type', {});
 
   t.true(client.flush.calledOnce);
 });
 
-test("enqueue - flush after a period of time", async t => {
+test('enqueue - flush after a period of time', async (t) => {
   const client = createClient({ flushInterval: 10 });
-  stub(client, "flush");
+  stub(client, 'flush');
 
-  client.enqueue("type", {});
+  client.enqueue('type', {});
 
   t.false(client.flush.called);
   await delay(20);
@@ -244,55 +245,55 @@ test("enqueue - flush after a period of time", async t => {
   t.true(client.flush.calledOnce);
 });
 
-test("enqueue - don't reset an existing timer", async t => {
+test("enqueue - don't reset an existing timer", async (t) => {
   const client = createClient({ flushInterval: 10 });
-  stub(client, "flush");
+  stub(client, 'flush');
 
-  client.enqueue("type", {});
+  client.enqueue('type', {});
   await delay(5);
-  client.enqueue("type", {});
+  client.enqueue('type', {});
   await delay(5);
 
   t.true(client.flush.calledOnce);
 });
 
-test("enqueue - extend context", t => {
+test('enqueue - extend context', (t) => {
   const client = createClient();
 
   client.enqueue(
-    "type",
+    'type',
     {
-      event: "test",
-      context: { name: "travis" }
+      event: 'test',
+      context: { name: 'travis' },
     },
     noop
   );
 
   const actualContext = client.queue[0].message.context;
-  const expectedContext = { ...context, name: "travis" };
+  const expectedContext = { ...context, name: 'travis' };
 
   t.deepEqual(actualContext, expectedContext);
 });
 
-test("enqueue - skip when client is disabled", async t => {
+test('enqueue - skip when client is disabled', async (t) => {
   const client = createClient({ enable: false });
-  stub(client, "flush");
+  stub(client, 'flush');
 
   const callback = spy();
-  client.enqueue("type", {}, callback);
+  client.enqueue('type', {}, callback);
   await delay(5);
 
   t.true(callback.calledOnce);
   t.false(client.flush.called);
 });
 
-test("flush - don't fail when queue is empty", async t => {
+test("flush - don't fail when queue is empty", async (t) => {
   const client = createClient();
 
   await t.notThrows(client.flush());
 });
 
-test("flush - send messages", async t => {
+test('flush - send messages', async (t) => {
   const client = createClient({ flushAt: 2 });
 
   const callbackA = spy();
@@ -300,15 +301,15 @@ test("flush - send messages", async t => {
   const callbackC = spy();
 
   client.queue = [];
-  client.identify({ userId: "id", traits: { traitOne: "a1" } }, callbackA);
-  client.page({ userId: "id", category: "category", name: "b1" }, callbackB);
-  client.track({ userId: "id", event: "c1" }, callbackC);
+  client.identify({ userId: 'id', traits: { traitOne: 'a1' } }, callbackA);
+  client.page({ userId: 'id', category: 'category', name: 'b1' }, callbackB);
+  client.track({ userId: 'id', event: 'c1' }, callbackC);
 
   const data = await client.flush();
-  t.deepEqual(Object.keys(data), ["batch", "sentAt"]);
-  var keys = Object.keys(data.batch[0]);
-  t.true(keys.includes("originalTimestamp"));
-  t.true(keys.includes("sentAt"));
+  t.deepEqual(Object.keys(data), ['batch', 'sentAt']);
+  const keys = Object.keys(data.batch[0]);
+  t.true(keys.includes('originalTimestamp'));
+  t.true(keys.includes('sentAt'));
   t.true(data.sentAt instanceof Date);
   // the below is erractic behaviour, need to check?
   // t.true(callbackA.calledOnce)
@@ -316,43 +317,43 @@ test("flush - send messages", async t => {
   // t.true(callbackC.called)
 });
 
-test("flush - respond with an error", async t => {
+test('flush - respond with an error', async (t) => {
   const client = createClient();
   const callback = spy();
 
   client.queue = [
     {
-      message: "error",
-      callback
-    }
+      message: 'error',
+      callback,
+    },
   ];
 
-  await t.throws(client.flush(), "Bad Request");
+  await t.throws(client.flush(), 'Bad Request');
 });
 
-test("flush - time out if configured", async t => {
+test('flush - time out if configured', async (t) => {
   const client = createClient({ timeout: 500 });
   const callback = spy();
 
   client.queue = [
     {
-      message: "timeout",
-      callback
-    }
+      message: 'timeout',
+      callback,
+    },
   ];
 
-  await t.throws(client.flush(), "timeout of 500ms exceeded");
+  await t.throws(client.flush(), 'timeout of 500ms exceeded');
 });
 
-test("flush - skip when client is disabled", async t => {
+test('flush - skip when client is disabled', async (t) => {
   const client = createClient({ enable: false });
   const callback = spy();
 
   client.queue = [
     {
-      message: "test",
-      callback
-    }
+      message: 'test',
+      callback,
+    },
   ];
 
   await client.flush();
@@ -360,209 +361,185 @@ test("flush - skip when client is disabled", async t => {
   t.false(callback.called);
 });
 
-test("identify - enqueue a message", t => {
+test('identify - enqueue a message', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  const message = { userId: "id" };
+  const message = { userId: 'id' };
   client.identify(message, noop);
 
   t.true(client.enqueue.calledOnce);
-  t.deepEqual(client.enqueue.firstCall.args, ["identify", message, noop]);
+  t.deepEqual(client.enqueue.firstCall.args, ['identify', message, noop]);
 });
 
-test("identify - require a userId or anonymousId", t => {
+test('identify - require a userId or anonymousId', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  t.throws(() => client.identify(), "You must pass a message object.");
-  t.throws(
-    () => client.identify({}),
-    'You must pass either an "anonymousId" or a "userId".'
-  );
-  t.notThrows(() => client.identify({ userId: "id" }));
-  t.notThrows(() => client.identify({ anonymousId: "id" }));
+  t.throws(() => client.identify(), 'You must pass a message object.');
+  t.throws(() => client.identify({}), 'You must pass either an "anonymousId" or a "userId".');
+  t.notThrows(() => client.identify({ userId: 'id' }));
+  t.notThrows(() => client.identify({ anonymousId: 'id' }));
 });
 
-test("group - enqueue a message", t => {
+test('group - enqueue a message', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
   const message = {
-    groupId: "id",
-    userId: "id"
+    groupId: 'id',
+    userId: 'id',
   };
 
   client.group(message, noop);
 
   t.true(client.enqueue.calledOnce);
-  t.deepEqual(client.enqueue.firstCall.args, ["group", message, noop]);
+  t.deepEqual(client.enqueue.firstCall.args, ['group', message, noop]);
 });
 
-test("group - require a groupId and either userId or anonymousId", t => {
+test('group - require a groupId and either userId or anonymousId', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  t.throws(() => client.group(), "You must pass a message object.");
-  t.throws(
-    () => client.group({}),
-    'You must pass either an "anonymousId" or a "userId".'
-  );
-  t.throws(() => client.group({ userId: "id" }), 'You must pass a "groupId".');
-  t.throws(
-    () => client.group({ anonymousId: "id" }),
-    'You must pass a "groupId".'
-  );
+  t.throws(() => client.group(), 'You must pass a message object.');
+  t.throws(() => client.group({}), 'You must pass either an "anonymousId" or a "userId".');
+  t.throws(() => client.group({ userId: 'id' }), 'You must pass a "groupId".');
+  t.throws(() => client.group({ anonymousId: 'id' }), 'You must pass a "groupId".');
   t.notThrows(() => {
     client.group({
-      groupId: "id",
-      userId: "id"
+      groupId: 'id',
+      userId: 'id',
     });
   });
 
   t.notThrows(() => {
     client.group({
-      groupId: "id",
-      anonymousId: "id"
+      groupId: 'id',
+      anonymousId: 'id',
     });
   });
 });
 
-test("track - enqueue a message", t => {
+test('track - enqueue a message', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
   const message = {
     userId: 1,
-    event: "event"
+    event: 'event',
   };
 
   client.track(message, noop);
 
   t.true(client.enqueue.calledOnce);
-  t.deepEqual(client.enqueue.firstCall.args, ["track", message, noop]);
+  t.deepEqual(client.enqueue.firstCall.args, ['track', message, noop]);
 });
 
-test("track - require event and either userId or anonymousId", t => {
+test('track - require event and either userId or anonymousId', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  t.throws(() => client.track(), "You must pass a message object.");
-  t.throws(
-    () => client.track({}),
-    'You must pass either an "anonymousId" or a "userId".'
-  );
-  t.throws(() => client.track({ userId: "id" }), 'You must pass an "event".');
-  t.throws(
-    () => client.track({ anonymousId: "id" }),
-    'You must pass an "event".'
-  );
+  t.throws(() => client.track(), 'You must pass a message object.');
+  t.throws(() => client.track({}), 'You must pass either an "anonymousId" or a "userId".');
+  t.throws(() => client.track({ userId: 'id' }), 'You must pass an "event".');
+  t.throws(() => client.track({ anonymousId: 'id' }), 'You must pass an "event".');
   t.notThrows(() => {
     client.track({
-      userId: "id",
-      event: "event"
+      userId: 'id',
+      event: 'event',
     });
   });
 
   t.notThrows(() => {
     client.track({
-      anonymousId: "id",
-      event: "event"
+      anonymousId: 'id',
+      event: 'event',
     });
   });
 });
 
-test("page - enqueue a message", t => {
+test('page - enqueue a message', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  const message = { userId: "id" };
+  const message = { userId: 'id' };
   client.page(message, noop);
 
   t.true(client.enqueue.calledOnce);
-  t.deepEqual(client.enqueue.firstCall.args, ["page", message, noop]);
+  t.deepEqual(client.enqueue.firstCall.args, ['page', message, noop]);
 });
 
-test("page - require either userId or anonymousId", t => {
+test('page - require either userId or anonymousId', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  t.throws(() => client.page(), "You must pass a message object.");
-  t.throws(
-    () => client.page({}),
-    'You must pass either an "anonymousId" or a "userId".'
-  );
-  t.notThrows(() => client.page({ userId: "id" }));
-  t.notThrows(() => client.page({ anonymousId: "id" }));
+  t.throws(() => client.page(), 'You must pass a message object.');
+  t.throws(() => client.page({}), 'You must pass either an "anonymousId" or a "userId".');
+  t.notThrows(() => client.page({ userId: 'id' }));
+  t.notThrows(() => client.page({ anonymousId: 'id' }));
 });
 
-test("screen - enqueue a message", t => {
+test('screen - enqueue a message', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  const message = { userId: "id" };
+  const message = { userId: 'id' };
   client.screen(message, noop);
 
   t.true(client.enqueue.calledOnce);
-  t.deepEqual(client.enqueue.firstCall.args, ["screen", message, noop]);
+  t.deepEqual(client.enqueue.firstCall.args, ['screen', message, noop]);
 });
 
-test("screen - require either userId or anonymousId", t => {
+test('screen - require either userId or anonymousId', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  t.throws(() => client.screen(), "You must pass a message object.");
-  t.throws(
-    () => client.screen({}),
-    'You must pass either an "anonymousId" or a "userId".'
-  );
-  t.notThrows(() => client.screen({ userId: "id" }));
-  t.notThrows(() => client.screen({ anonymousId: "id" }));
+  t.throws(() => client.screen(), 'You must pass a message object.');
+  t.throws(() => client.screen({}), 'You must pass either an "anonymousId" or a "userId".');
+  t.notThrows(() => client.screen({ userId: 'id' }));
+  t.notThrows(() => client.screen({ anonymousId: 'id' }));
 });
 
-test("alias - enqueue a message", t => {
+test('alias - enqueue a message', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
   const message = {
-    userId: "id",
-    previousId: "id"
+    userId: 'id',
+    previousId: 'id',
   };
 
   client.alias(message, noop);
 
   t.true(client.enqueue.calledOnce);
-  t.deepEqual(client.enqueue.firstCall.args, ["alias", message, noop]);
+  t.deepEqual(client.enqueue.firstCall.args, ['alias', message, noop]);
 });
 
-test("alias - require previousId and userId", t => {
+test('alias - require previousId and userId', (t) => {
   const client = createClient();
-  stub(client, "enqueue");
+  stub(client, 'enqueue');
 
-  t.throws(() => client.alias(), "You must pass a message object.");
+  t.throws(() => client.alias(), 'You must pass a message object.');
   t.throws(() => client.alias({}), 'You must pass a "userId".');
-  t.throws(
-    () => client.alias({ userId: "id" }),
-    'You must pass a "previousId".'
-  );
+  t.throws(() => client.alias({ userId: 'id' }), 'You must pass a "previousId".');
   t.notThrows(() => {
     client.alias({
-      userId: "id",
-      previousId: "id"
+      userId: 'id',
+      previousId: 'id',
     });
   });
 });
 
-test("isErrorRetryable", t => {
+test('isErrorRetryable', (t) => {
   const client = createClient();
 
   t.false(client._isErrorRetryable({}));
 
   // ETIMEDOUT is retryable as per `is-retry-allowed` (used by axios-retry in `isNetworkError`).
-  t.true(client._isErrorRetryable({ code: "ETIMEDOUT" }));
+  t.true(client._isErrorRetryable({ code: 'ETIMEDOUT' }));
 
   // ECONNABORTED is not retryable as per `is-retry-allowed` (used by axios-retry in `isNetworkError`).
-  t.false(client._isErrorRetryable({ code: "ECONNABORTED" }));
+  t.false(client._isErrorRetryable({ code: 'ECONNABORTED' }));
 
   t.true(client._isErrorRetryable({ response: { status: 500 } }));
   t.true(client._isErrorRetryable({ response: { status: 429 } }));
@@ -570,16 +547,16 @@ test("isErrorRetryable", t => {
   t.false(client._isErrorRetryable({ response: { status: 200 } }));
 });
 
-test("allows messages > 32kb", t => {
+test('allows messages > 32kb', (t) => {
   const client = createClient();
 
   const event = {
     userId: 1,
-    event: "event",
-    properties: {}
+    event: 'event',
+    properties: {},
   };
-  for (var i = 0; i < 100; i++) {
-    event.properties[i] = "a";
+  for (let i = 0; i < 100; i++) {
+    event.properties[i] = 'a';
   }
 
   t.notThrows(() => {


### PR DESCRIPTION
Why: fix up the files so there are no lint warnings so we can keep it that way. Disable CI tests since they hang and consume CI minutes for now.

How: `yarn lint --fix` for style. Changed `==` to `===` in two places doing library-internal string comparisons were it was safe to do so.

Test Plan: `yarn tsc` and `yarn test` - same test pass as before