### PR TITLE
[ts] Add more comprehensive TypeScript types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,20 @@
+Unpublished
+==========================
+
+### Breaking changes
+
+* The main Analytics class is now a default export instead of being the value of `module.exports`. If you're using `require` with this library, you'll need to write `require('@expo/rudder-sdk-node').default`. If you're using `import` with this library, no changes are needed.
+* Removed support for persisting events in Redis
+* Changed the logger from `winston` to `bunyan` (specifically, `@expo/bunyan`)
+* Changed the default log level from INFO to FATAL
+
+### Minor changes
+
+* Convert from JavaScript to TypeScript. First-class type 
+* Replaced `axios` with `node-fetch`
+* The library name in the log context object is now `@expo/rudder-sdk-node`
+* The user agent string is now `expo-rudder-sdk-node/<version>`
+
 v1.0.8
 ==========================
 

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 const program = require('commander');
 
-const Analytics = require('.');
+const Analytics = require('.').default;
 const pkg = require('./package');
 
 const toObject = (str) => JSON.parse(str);

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,9 @@ export type AnalyticsMessage = AnalyticsIdentity & {
   [key: string]: unknown;
 };
 
-export type AnalyticsIdentity = { userId: string } | { anonymousId: string };
+export type AnalyticsIdentity =
+  | { userId: string | number }
+  | { userId?: string | number; anonymousId: string };
 
 export type AnalyticsMessageCallback = (error?: Error) => void;
 
@@ -51,7 +53,7 @@ export default class Analytics {
 
   private readonly writeKey: string;
   private readonly host: string;
-  private readonly timeout: number | string | null;
+  private readonly timeout: number | string;
 
   private readonly flushAt: number;
   private readonly flushInterval: number;

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import fetchRetry from 'fetch-retry';
 import isString from 'lodash.isstring';
 import md5 from 'md5';
 import ms from 'ms';
-import fetch from 'node-fetch';
+import fetch, { Response } from 'node-fetch';
 import removeTrailingSlash from 'remove-trailing-slash';
 import { v4 as uuid } from 'uuid';
 
@@ -13,33 +13,54 @@ const version = require('./package.json').version;
 
 const retryableFetch = fetchRetry(fetch as any) as unknown as typeof fetch;
 const setImmediate = global.setImmediate || process.nextTick.bind(process);
-const noop = () => {};
 
-enum AnalyticsState {
+export type AnalyticsMessage = AnalyticsIdentity & {
+  context?: { [key: string]: unknown };
+  traits?: { [key: string]: unknown };
+  integrations?: { [destination: string]: boolean };
+  timestamp?: Date;
+  [key: string]: unknown;
+};
+
+export type AnalyticsIdentity = { userId: string } | { anonymousId: string };
+
+export type AnalyticsMessageCallback = (error?: Error) => void;
+
+export type AnalyticsFlushCallback = (
+  error?: Error,
+  data?: { batch: AnalyticsPayload[]; sentAt: Date }
+) => void;
+
+type AnalyticsPayload = any;
+
+type AnalyticsEventType = 'identify' | 'track' | 'page' | 'screen' | 'group' | 'alias';
+
+const enum AnalyticsState {
   Idle = 'idle',
   Running = 'running',
 }
 
-type AnalyticsMessage = any;
-
-class Analytics {
+export default class Analytics {
   private readonly enable: boolean;
-  private state = AnalyticsState.Idle;
-  private queue = [] as {
-    message: AnalyticsMessage;
-    callback: (error?: Error, data?: { batch: AnalyticsMessage[]; sentAt: Date }) => void;
-  }[];
-  private writeKey: string;
-  private host: string;
-  private timeout: number | null;
-  private flushAt: number;
-  private flushInterval: number;
-  private maxInternalQueueSize: number;
-  private flushed: boolean = false;
-  private flushTimer: NodeJS.Timer | null = null;
-  private timer: NodeJS.Timer | null = null;
 
-  private logger: bunyan;
+  private state = AnalyticsState.Idle;
+  private readonly queue = [] as {
+    message: AnalyticsPayload;
+    callback: AnalyticsMessageCallback;
+  }[];
+
+  private readonly writeKey: string;
+  private readonly host: string;
+  private readonly timeout: number | string | null;
+
+  private readonly flushAt: number;
+  private readonly flushInterval: number;
+  private readonly maxInternalQueueSize: number;
+  private flushed: boolean = false;
+  private timer: NodeJS.Timer | null = null;
+  private flushTimer: NodeJS.Timer | null = null;
+
+  private readonly logger: bunyan;
 
   /**
    * Initialize a new `Analytics` instance with your RudderStack project's `writeKey` and an
@@ -57,20 +78,22 @@ class Analytics {
       logLevel = bunyan.FATAL,
     }: {
       enable?: boolean;
-      timeout?: number;
+      timeout?: number | string;
       flushAt?: number;
       flushInterval?: number;
       maxInternalQueueSize?: number;
       logLevel?: bunyan.LogLevel;
     } = {}
   ) {
-    assert(writeKey, `You must pass your project's write key.`);
-    assert(dataPlaneURL, `You must pass your data plane URL.`);
+    this.enable = enable;
+
+    assert(writeKey, `The project's write key must be specified`);
+    assert(dataPlaneURL, `The data plane URL must be specified`);
 
     this.writeKey = writeKey;
     this.host = removeTrailingSlash(dataPlaneURL);
-    this.enable = enable;
     this.timeout = timeout;
+
     this.flushAt = Math.max(flushAt, 1);
     this.flushInterval = flushInterval;
     this.maxInternalQueueSize = maxInternalQueueSize;
@@ -81,13 +104,80 @@ class Analytics {
     });
   }
 
-  _validate(message, type) {
+  /**
+   * Sends an "identify" message that associates traits with a user.
+   */
+  identify(message: AnalyticsMessage, callback?: AnalyticsMessageCallback): Analytics {
+    this.validate(message, 'identify');
+    this.enqueue('identify', message, callback);
+    return this;
+  }
+
+  /**
+   * Sends a "group" message that identifies this user with a group.
+   */
+  group(
+    message: AnalyticsMessage & { groupId: string },
+    callback?: AnalyticsMessageCallback
+  ): Analytics {
+    this.validate(message, 'group');
+    this.enqueue('group', message, callback);
+    return this;
+  }
+
+  /**
+   * Sends a "track" event that records an action.
+   */
+  track(
+    message: AnalyticsMessage & { event: string },
+    callback?: AnalyticsMessageCallback
+  ): Analytics {
+    this.validate(message, 'track');
+    this.enqueue('track', message, callback);
+    return this;
+  }
+
+  /**
+   * Sends a "page" event that records a page view on a website.
+   */
+  page(
+    message: AnalyticsMessage & { name: string },
+    callback?: AnalyticsMessageCallback
+  ): Analytics {
+    this.validate(message, 'page');
+    this.enqueue('page', message, callback);
+    return this;
+  }
+
+  /**
+   * Sends a "screen" event that records a screen view in an app.
+   */
+
+  screen(message: AnalyticsMessage, callback?: AnalyticsMessageCallback): Analytics {
+    this.validate(message, 'screen');
+    this.enqueue('screen', message, callback);
+    return this;
+  }
+
+  /**
+   * Sends an "alias" message that associates one ID with another.
+   */
+  alias(
+    message: { previousId: string } & AnalyticsIdentity,
+    callback?: AnalyticsMessageCallback
+  ): Analytics {
+    this.validate(message, 'alias');
+    this.enqueue('alias', message, callback);
+    return this;
+  }
+
+  private validate(message: Partial<AnalyticsMessage>, type: AnalyticsEventType): void {
     try {
       looselyValidate(message, type);
     } catch (e) {
       if (e.message === 'Your message must be < 32kb.') {
         this.logger.info(
-          'Your message must be < 32kb. This is currently surfaced as a warning. Please update your code',
+          'Your message must be < 32KiB. This is currently surfaced as a warning. Please update your code.',
           message
         );
         return;
@@ -97,144 +187,19 @@ class Analytics {
   }
 
   /**
-   * Send an identify `message`.
-   *
-   * @param {Object} message
-   * @param {String=} message.userId (optional)
-   * @param {String=} message.anonymousId (optional)
-   * @param {Object=} message.context (optional)
-   * @param {Object=} message.traits (optional)
-   * @param {Object=} message.integrations (optional)
-   * @param {Date=} message.timestamp (optional)
-   * @param {Function=} callback (optional)
-   * @return {Analytics}
+   * Adds a message of the specified type to the queue and flushes the queue if appropriate.
    */
-
-  identify(message, callback) {
-    this._validate(message, 'identify');
-    this.enqueue('identify', message, callback);
-    return this;
-  }
-
-  /**
-   * Send a group `message`.
-   *
-   * @param {Object} message
-   * @param {String} message.groupId
-   * @param {String=} message.userId (optional)
-   * @param {String=} message.anonymousId (optional)
-   * @param {Object=} message.context (optional)
-   * @param {Object=} message.traits (optional)
-   * @param {Object=} message.integrations (optional)
-   * @param {Date=} message.timestamp (optional)
-   * @param {Function=} callback (optional)
-   * @return {Analytics}
-   */
-
-  group(message, callback) {
-    this._validate(message, 'group');
-    this.enqueue('group', message, callback);
-    return this;
-  }
-
-  /**
-   * Send a track `message`.
-   *
-   * @param {Object} message
-   * @param {String} message.event
-   * @param {String=} message.userId (optional)
-   * @param {String=} message.anonymousId (optional)
-   * @param {Object=} message.context (optional)
-   * @param {Object=} message.properties (optional)
-   * @param {Object=} message.integrations (optional)
-   * @param {Date=} message.timestamp (optional)
-   * @param {Function=} callback (optional)
-   * @return {Analytics}
-   */
-
-  track(message, callback) {
-    this._validate(message, 'track');
-    this.enqueue('track', message, callback);
-    return this;
-  }
-
-  /**
-   * Send a page `message`.
-   *
-   * @param {Object} message
-   * @param {String} message.name
-   * @param {String=} message.userId (optional)
-   * @param {String=} message.anonymousId (optional)
-   * @param {Object=} message.context (optional)
-   * @param {Object=} message.properties (optional)
-   * @param {Object=} message.integrations (optional)
-   * @param {Date=} message.timestamp (optional)
-   * @param {Function=} callback (optional)
-   * @return {Analytics}
-   */
-
-  page(message, callback) {
-    this._validate(message, 'page');
-    this.enqueue('page', message, callback);
-    return this;
-  }
-
-  /**
-   * Send a screen `message`.
-   *
-   * @param {Object} message
-   * @param {Function} fn (optional)
-   * @return {Analytics}
-   */
-
-  screen(message, callback) {
-    this._validate(message, 'screen');
-    this.enqueue('screen', message, callback);
-    return this;
-  }
-
-  /**
-   * Send an alias `message`.
-   *
-   * @param {Object} message
-   * @param {String} message.previousId
-   * @param {String=} message.userId (optional)
-   * @param {String=} message.anonymousId (optional)
-   * @param {Object=} message.context (optional)
-   * @param {Object=} message.properties (optional)
-   * @param {Object=} message.integrations (optional)
-   * @param {Date=} message.timestamp (optional)
-   * @param {Function=} callback (optional)
-   * @return {Analytics}
-   */
-
-  alias(message, callback) {
-    this._validate(message, 'alias');
-    this.enqueue('alias', message, callback);
-    return this;
-  }
-
-  /**
-   * Add a `message` of type `type` to the queue and
-   * check whether it should be flushed.
-   *
-   * @param {String} type
-   * @param {Object} message
-   * @param {Function} [callback] (optional)
-   * @api private
-   */
-
-  enqueue(type, message, callback): void {
+  private enqueue(
+    type: AnalyticsEventType,
+    message: any,
+    callback: AnalyticsMessageCallback = () => {}
+  ): void {
     if (this.queue.length >= this.maxInternalQueueSize) {
       this.logger.error(
-        'not adding events for processing as queue size ' +
-          this.queue.length +
-          ' >= than max configuration ' +
-          this.maxInternalQueueSize
+        `Not adding events for processing as queue size ${this.queue.length} exceeds max configuration ${this.maxInternalQueueSize}`
       );
       return;
     }
-    callback = callback || noop;
 
     if (!this.enable) {
       setImmediate(callback);
@@ -308,13 +273,9 @@ class Analytics {
   }
 
   /**
-   * Flush the current queue
-   *
-   * @param {Function} [callback] (optional)
-   * @return {Analytics}
+   * Flushes the message queue to the server immediately if a flush is not already in progress.
    */
-
-  flush(callback?) {
+  flush(callback: AnalyticsFlushCallback = () => {}): void {
     // check if earlier flush was pushed to queue
     this.logger.debug('in flush');
     if (this.state === AnalyticsState.Running) {
@@ -322,7 +283,6 @@ class Analytics {
       return;
     }
     this.state = AnalyticsState.Running;
-    callback = callback || noop;
 
     if (!this.enable) {
       this.state = AnalyticsState.Idle;
@@ -366,7 +326,7 @@ class Analytics {
     this.logger.debug('batch size is ' + items.length);
     this.logger.trace('===data===', data);
 
-    const done = (err?) => {
+    const done = (err?: Error) => {
       callbacks.forEach((callback_) => {
         callback_(err);
       });
@@ -386,8 +346,8 @@ class Analytics {
         Authorization: 'Basic ' + Buffer.from(`${this.writeKey}:`).toString('base64'),
       },
       body: JSON.stringify(data),
-      retryDelay: this._exponentialDelay.bind(this),
-      retryOn: this._isErrorRetryable.bind(this),
+      retryDelay: this.getExponentialDelay.bind(this),
+      retryOn: this.isErrorRetryable.bind(this),
     };
 
     if (this.timeout) {
@@ -417,34 +377,39 @@ class Analytics {
       });
   }
 
-  _exponentialDelay(attempt, _error, _response) {
-    const delay = Math.pow(2, attempt + 1) * 200;
-    const randomSum = delay * 0.2 * Math.random(); // 0-20% of the delay
-    return delay + randomSum;
+  /**
+   * Calculates the amount of time to wait before retrying a request, given the number of prior
+   * retries (excluding the initial attempt).
+   *
+   * @param priorRetryCount the number of prior retries, starting from zero
+   */
+  private getExponentialDelay(priorRetryCount: number): number {
+    const delay = 2 ** priorRetryCount * 200;
+    const jitter = delay * 0.2 * Math.random(); // 0-20% of the delay
+    return delay + jitter;
   }
 
-  _isErrorRetryable(attempt, error, response) {
+  /**
+   * Returns whether to retry a request that failed with the given error or returned the given
+   * response.
+   */
+  private isErrorRetryable(
+    priorRetryCount: number,
+    error: Error | null,
+    response: Response
+  ): boolean {
     // 3 retries max
-    if (attempt > 2) {
+    if (priorRetryCount > 2) {
       return false;
     }
 
-    // retry on any network error
-    if (error !== null) {
-      return true;
-    }
-    // retry on 5xx status codes
-    else if (response.status >= 500 && response.status <= 599) {
-      return true;
-    }
-    // Retry if rate limited
-    else if (response.status === 429) {
-      return true;
-      // All other cases, do not retry
-    } else {
-      return false;
-    }
+    return (
+      // Retry on any network error
+      !!error ||
+      // Retry if rate limited
+      response.status === 429 ||
+      // Retry on 5xx status codes due to server errors
+      (response.status >= 500 && response.status <= 599)
+    );
   }
 }
-
-export = Analytics;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
     "changelog": "auto-changelog -p -t keepachangelog -u true -l false --sort-commits date-desc "
   },
   "main": "index.js",
+  "files": [
+    "cli.js",
+    "index.d.ts",
+    "index.js",
+    "index.ts"
+  ],
   "keywords": [
     "analytics"
   ],

--- a/test.js
+++ b/test.js
@@ -72,7 +72,7 @@ test('expose a constructor', (t) => {
 });
 
 test('require a write key', (t) => {
-  t.throws(() => new Analytics(), "You must pass your project's write key.");
+  t.throws(() => new Analytics(), "The project's write key must be specified");
 });
 
 test('create a queue', (t) => {
@@ -82,7 +82,7 @@ test('create a queue', (t) => {
 });
 
 test('default options', (t) => {
-  t.throws(() => new Analytics('key'), 'You must pass your data plane URL.');
+  t.throws(() => new Analytics('key'), 'The data plane URL must be specified');
 });
 
 test('remove trailing slashes from `host`', (t) => {
@@ -533,18 +533,18 @@ test('alias - require previousId and userId', (t) => {
 test('isErrorRetryable', (t) => {
   const client = createClient();
 
-  t.false(client._isErrorRetryable({}));
+  t.false(client.isErrorRetryable({}));
 
   // ETIMEDOUT is retryable as per `is-retry-allowed` (used by axios-retry in `isNetworkError`).
-  t.true(client._isErrorRetryable({ code: 'ETIMEDOUT' }));
+  t.true(client.isErrorRetryable({ code: 'ETIMEDOUT' }));
 
   // ECONNABORTED is not retryable as per `is-retry-allowed` (used by axios-retry in `isNetworkError`).
-  t.false(client._isErrorRetryable({ code: 'ECONNABORTED' }));
+  t.false(client.isErrorRetryable({ code: 'ECONNABORTED' }));
 
-  t.true(client._isErrorRetryable({ response: { status: 500 } }));
-  t.true(client._isErrorRetryable({ response: { status: 429 } }));
+  t.true(client.isErrorRetryable({ response: { status: 500 } }));
+  t.true(client.isErrorRetryable({ response: { status: 429 } }));
 
-  t.false(client._isErrorRetryable({ response: { status: 200 } }));
+  t.false(client.isErrorRetryable({ response: { status: 200 } }));
 });
 
 test('allows messages > 32kb', (t) => {


### PR DESCRIPTION
# Why
More complete type definitions will make them more useful when using this library and also add more comprehensive type checking when working on this library. I think this will be especially useful when logging events and figuring out what fields need to be passed in.

# How
Added types for nearly the entire public API, including the methods like `identify`, `track`, and so on. Read the docs here https://segment.com/docs/connections/sources/catalog/libraries/server/node/ to see what constraints were on the payload types -- specifically I looked beyond the Node documentation at the server API since it was closer to the source of truth and more accurate than the Node documentation.

Along the way I rewrote some docblocks and rearranged properties and methods to group them semantically and put the more salient methods first.

I didn't type the internal message payload format yet to keep this PR from getting too large but is not a big part of the public API. There are some small but breaking changes that will help cull down the code some more before going further.

There is also a change in the exponential backoff function: instead of adding 1 to the retry count, just use the retry count starting from zero since 2^0 = 1.

# Test Plan
`yarn build; yarn test` and verified that the same tests passed/failed as before