### PR TITLE
[gitignore] Reorganize .gitignore, add macOS and editor ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
-node_modules
-coverage
-.nyc_output
-coverage.lcov
+# macOS
+.DS_Store
+
+# Editors
+*~
+/.vscode/
+
+# Node
+/node_modules/
+
+# Coverage
+/.nyc_output/
+/coverage/
+/coverage.lcov
+
+# Built files
 /index.d.ts
 /index.js
-


### PR DESCRIPTION
Why/How: we weren't ignoring common files that macOS and editors create. Also added headings to more neatly organize the .gitignore file

Test Plan: run git status, see that all of the generated files in the repo are still ignored