### PR TITLE
Always send UA string, lowercase headers, make test case-insensitive

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -330,16 +330,10 @@ export default class Analytics {
     const req = {
       method: 'POST',
       headers: {
-        Accept: 'application/json, text/plain, */*',
-        'Content-Type': 'application/json;charset=utf-8',
-        // Don't set the user agent if we're not on a browser. The latest spec allows
-        // the User-Agent header (see https://fetch.spec.whatwg.org/#terminology-headers
-        // and https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader),
-        // but browsers such as Chrome and Safari have not caught up.
-        ...(typeof window === 'undefined'
-          ? { 'user-agent': `expo-rudder-sdk-node/${version}` }
-          : null),
-        Authorization: 'Basic ' + Buffer.from(`${this.writeKey}:`).toString('base64'),
+        accept: 'application/json, text/plain, */*',
+        'content-type': 'application/json;charset=utf-8',
+        'user-agent': `expo-rudder-sdk-node/${version}`,
+        authorization: 'Basic ' + Buffer.from(`${this.writeKey}:`).toString('base64'),
       },
       body: JSON.stringify(data),
       timeout: this.timeout > 0 ? this.timeout : undefined,

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ test.before.cb((t) => {
         });
       }
 
-      const ua = req.headers['user-agent'];
+      const ua = req.get('user-agent');
       if (ua !== `expo-rudder-sdk-node/${version}`) {
         return res.status(400).json({
           error: { message: 'invalid user-agent' },


### PR DESCRIPTION
Why: This code always runs on Node and therefore we don't need the logic to selectively send the UA string -- just always send it.

The test was also using `request.headers[key]` instead of `request.get(key)`, which is case-insensitive.

How: always send the UA header. Lowercase them to match HTTP/2 where they are always lowercased.

Test Plan: `yarn test`