### PR TITLE
[ts] Add "types" field in package.json, include source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 # Built files
 /index.d.ts
 /index.js
+/index.js.map

--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
     "changelog": "auto-changelog -p -t keepachangelog -u true -l false --sort-commits date-desc "
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "cli.js",
     "index.d.ts",
     "index.js",
-    "index.ts"
+    "index.js.map"
   ],
   "keywords": [
     "analytics"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "noImplicitAny": false,
       "noImplicitReturns": true,
       "noFallthroughCasesInSwitch": true,
+      "sourceMap": true,
       "useUnknownInCatchVariables": false
     },
 }


### PR DESCRIPTION
Why
---

* TS wants us to specify "types" in package.json - we point it at the entrypoint index.d.ts file.
* Instead of publishing the whole index.ts file, publish just the source maps

How
---

Enabled source map generation. Added source maps to gitignore. Made sure source maps were published to npm.

Test Plan
---------

```
$ npm pack

> @expo/rudder-sdk-node@1.0.8 prepare rudder-sdk-node
> tsc

npm notice
npm notice 📦  @expo/rudder-sdk-node@1.0.8
npm notice === Tarball Contents ===
npm notice 3.0kB  cli.js
npm notice 10.4kB index.js
npm notice 1.8kB  package.json
npm notice 7.7kB  index.js.map
npm notice 2.2kB  HISTORY.md
npm notice 1.1kB  LICENSE.md
npm notice 1.2kB  README.md
npm notice 4.1kB  index.d.ts
```