### PR TITLE
[sdk] Enforce a single in-flight flush at a time

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,8 +9,11 @@ Unpublished
 * Changed the default log level from INFO to FATAL
 * The `timeout` option must be a number (milliseconds). Strings are no longer supported. As before, 0 means no timeout but now negative numbers also disable timeouts.
 * Changed how `flush()` works
-    * `flush()` now enforces a limit of one concurrent request at a time
-        * subsequent `flush()` requests will be enqueued and processed after the current flush resolves
+    * `flush()` now sends all messages present in the message queue at the time of the request
+        * previously `flush()` would only send `flushAt` number of events
+    * `flush()` now guards against batch sizes too large for the server via the configurable `maxFlushSizeInBytes` property. Trimmed messages remain in the queue for subsequent HTTP requests.
+    * `flush()` now enforces a limit of one concurrent HTTP request at a time
+        * simultaneous `flush()` requests will be handled when the current HTTP request finishes
     * Flushing will now occur
         * the first time an event is enqueued after instantiation (occurs immediately)
         * when the message queue size is divisible by `flushAt` (occurs immediately)
@@ -19,7 +22,6 @@ Unpublished
     * `flush()` is now an async function.
     * `flush()` no longer throws upon failure but returns an error object instead.
     * Changed when fetch requests are retried - All network errors are retried.
-    * `flush()` now guards against requests which are too large for the server via the configurable `maxFlushSizeInBytes` property. Trimmed messages remain in the queue for future processing.
 * No longer causes an exiting process to indefinitely stall due to a looping timer. If a process is naturally exiting (not due to `process.exit()`), you must call `analytics.flush()` to send the last events for them to be sent.
 * The `userId` and `anonymousId` message fields must be primitive strings. Other types like numbers are not supported.
 
@@ -29,7 +31,7 @@ Unpublished
 * Replaced `axios` with `node-fetch`
 * The library name in the log context object is now `@expo/rudder-sdk-node`
 * The user agent string is now `expo-rudder-sdk-node/<version>`
-* enqueue now limits the max events in the queue via configurable `maxMessageQueueLength` property.  If `enqueue()` is called and the message queue is already at or above the `maxMessageQueueLength` that message is dropped.
+* enqueue now limits the max events in the queue via configurable `maxQueueLength` property.  If `enqueue()` is called and the message queue is already at or above the `maxQueueLength` that message is dropped.
 
 v1.0.8
 ==========================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,16 +8,20 @@ Unpublished
 * Changed the logger from `winston` to `bunyan` (specifically, `@expo/bunyan`)
 * Changed the default log level from INFO to FATAL
 * The `timeout` option must be a number (milliseconds). Strings are no longer supported. As before, 0 means no timeout but now negative numbers also disable timeouts.
-* Changed how flushing works. Removes `flushTimer`, `AnalyticsState`. Flushing will only occur when
-    * the first time an event is enqueued after instantiation (occurs immediately)
-    * when the event queue size reaches the `flushAt` number (occurs immediately)
-    * when a new event is enqueued after a flush (a timer is set for flush to occur after `flushInterval` ms)
-* Changed how fetch is handled
-    * All network errors are retried
+* Changed how `flush()` works
+    * `flush()` now enforces a limit of one concurrent request at a time
+        * subsequent `flush()` requests will be enqueued and processed after the current flush resolves
+    * Flushing will now occur
+        * the first time an event is enqueued after instantiation (occurs immediately)
+        * when the message queue size is divisible by `flushAt` (occurs immediately)
+        * when a new event is enqueued after a flush (a timer is set for flush to occur after `flushInterval` ms)
+        * when a user requests a `flush()`
+    * `flush()` is now an async function.
+    * `flush()` no longer throws upon failure but returns an error object instead.
+    * Changed when fetch requests are retried - All network errors are retried.
+    * `flush()` now guards against requests which are too large for the server via the configurable `maxFlushSizeInBytes` property. Trimmed messages remain in the queue for future processing.
 * No longer causes an exiting process to indefinitely stall due to a looping timer. If a process is naturally exiting (not due to `process.exit()`), you must call `analytics.flush()` to send the last events for them to be sent.
 * The `userId` and `anonymousId` message fields must be primitive strings. Other types like numbers are not supported.
-* `flush()` is now an async function.
-* `flush()` no longer throws upon failure but returns an error object instead.
 
 ### Minor changes
 
@@ -25,9 +29,7 @@ Unpublished
 * Replaced `axios` with `node-fetch`
 * The library name in the log context object is now `@expo/rudder-sdk-node`
 * The user agent string is now `expo-rudder-sdk-node/<version>`
-* Events are now removed from the event queue prior to sending a network request, rather than after
-* flush now guards against requests which are too large via configurable `maxFlushSizeInBytes` property
-* enqueue now limits the max events in the queue via configurable `maxQueueLength` property
+* enqueue now limits the max events in the queue via configurable `maxMessageQueueLength` property.  If `enqueue()` is called and the message queue is already at or above the `maxMessageQueueLength` that message is dropped.
 
 v1.0.8
 ==========================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,15 +3,15 @@ Unpublished
 
 ### Breaking changes
 
-* The main Analytics class is now a default export instead of being the value of `module.exports`. If you're using `require` with this library, you'll need to write `require('@expo/rudder-sdk-node').default`. If you're using `import` with this library, no changes are needed.
+* The main Analytics class is now a default export instead of being the value of `module.exports`. If you're using `require` with this library, you'll need to write `require('@expo/rudder-sdk-node').default`. If you're using `import` with this library, no changes are needed
 * Removed support for persisting events in Redis
 * Changed the logger from `winston` to `bunyan` (specifically, `@expo/bunyan`)
 * Changed the default log level from INFO to FATAL
-* The `timeout` option must be a number (milliseconds). Strings are no longer supported. As before, 0 means no timeout but now negative numbers also disable timeouts.
+* The `timeout` option must be a number (milliseconds). Strings are no longer supported. As before, 0 means no timeout but now negative numbers also disable timeouts
 * Changed how `flush()` works
     * `flush()` now sends all messages present in the message queue at the time of the request
         * previously `flush()` would only send `flushAt` number of events
-    * `flush()` now guards against batch sizes too large for the server via the configurable `maxFlushSizeInBytes` property. Trimmed messages remain in the queue for subsequent HTTP requests.
+    * `flush()` now guards against batch sizes too large for the server via the configurable `maxFlushSizeInBytes` property. Trimmed messages remain in the queue for subsequent HTTP requests
     * `flush()` now enforces a limit of one concurrent HTTP request at a time
         * simultaneous `flush()` requests will be handled when the current HTTP request finishes
     * Flushing will now occur
@@ -19,11 +19,13 @@ Unpublished
         * when the message queue size is divisible by `flushAt` (occurs immediately)
         * when a new event is enqueued after a flush (a timer is set for flush to occur after `flushInterval` ms)
         * when a user requests a `flush()`
-    * `flush()` is now an async function.
-    * `flush()` no longer throws upon failure but returns an error object instead.
-    * Changed when fetch requests are retried - All network errors are retried.
-* No longer causes an exiting process to indefinitely stall due to a looping timer. If a process is naturally exiting (not due to `process.exit()`), you must call `analytics.flush()` to send the last events for them to be sent.
-* The `userId` and `anonymousId` message fields must be primitive strings. Other types like numbers are not supported.
+    * `flush()` is now an async function
+    * `flush()` now has a return type of `Promise<FlushResponse[]>`
+    * flush callbacks now accept arguments of type `FlushResponse[]`
+    * `flush()` no longer throws upon failure but returns an error object instead
+    * Changed when fetch requests are retried - All network errors are retried
+* No longer causes an exiting process to indefinitely stall due to a looping timer. If a process is naturally exiting (not due to `process.exit()`), you must call `analytics.flush()` to send the last events for them to be sent
+* The `userId` and `anonymousId` message fields must be primitive strings. Other types like numbers are not supported
 
 ### Minor changes
 
@@ -31,7 +33,7 @@ Unpublished
 * Replaced `axios` with `node-fetch`
 * The library name in the log context object is now `@expo/rudder-sdk-node`
 * The user agent string is now `expo-rudder-sdk-node/<version>`
-* enqueue now limits the max events in the queue via configurable `maxQueueLength` property.  If `enqueue()` is called and the message queue is already at or above the `maxQueueLength` that message is dropped.
+* enqueue now limits the max events in the queue via configurable `maxQueueLength` property.  If `enqueue()` is called and the message queue is already at or above the `maxQueueLength` that message is dropped
 
 v1.0.8
 ==========================


### PR DESCRIPTION
# Why

We'd like a more deterministic approach to flushes to ensure events make it to the backend as expected.

# How

- flush will now send as many events as possible in each batch
- flush now handles simultaneous requests by recursively calling itself
- updated tests to work with the new algorithm
- reworked callbacks to be a queue to account for simultaneous flush calls
- flush now has a return type of `Promise<FlushResponse[]>`

# Test Plan

I added some tests which should catch any issues with the new functionality.