### PR TITLE
[sdk] Require traits object in identify

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -117,6 +117,9 @@ export default class Analytics {
     callback?: AnalyticsMessageCallback
   ): Analytics {
     this.validate(message, 'identify');
+    if (!message.traits) {
+      message.traits = {};
+    }
     this.enqueue('identify', message, callback);
     return this;
   }

--- a/index.ts
+++ b/index.ts
@@ -117,9 +117,6 @@ export default class Analytics {
     callback?: AnalyticsMessageCallback
   ): Analytics {
     this.validate(message, 'identify');
-    if (!message.traits) {
-      message.traits = {};
-    }
     this.enqueue('identify', message, callback);
     return this;
   }
@@ -220,12 +217,9 @@ export default class Analytics {
     }
 
     if (type === 'identify') {
-      if (message.traits) {
-        if (!message.context) {
-          message.context = {};
-        }
-        message.context.traits = message.traits;
-      }
+      message.traits ??= {};
+      message.context ??= {};
+      message.context.traits = message.traits;
     }
 
     message = { ...message };


### PR DESCRIPTION
# Why

https://www.notion.so/expo/Amplitude-Dest-Transformer-Errors-9-22-9-23-b0bdc6b53f8540f9b6b4ef22265be3c0

# How

Added empty traits object if it does not already exist on `identify` messages before enqueueing them.

# Test Plan

Have confirmed this fixes the errors by querying the `proc_error_jobs` database (and not seeing messages using this SDK appear there).