### PR TITLE
[sdk][test] fixes null response behavior

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+unpublished
+==========================
+### Minor changes
+- adds some more verbose logging for future debugging
+
+### Bug Fixes
+- fixed an issue where returning a `nullResponse` from a flush resulted in future flushes returning that `nullResponse`.
+
 v1.1.0
 ==========================
 

--- a/index.ts
+++ b/index.ts
@@ -288,18 +288,27 @@ export default class Analytics {
    * Flushes the message queue to the server immediately if a flush is not already in progress.
    */
   async flush(callback: AnalyticsFlushCallback = () => {}): Promise<FlushResponse[]> {
+    this.logger.debug('in flush');
+
     // will cause new messages to be rolled up into the in-flight flush
     this.finalMessageId = this.queue.length
       ? this.queue[this.queue.length - 1].message.messageId
       : null;
+    this.logger.trace('finalMessageId: ' + this.finalMessageId);
     this.flushCallbacks.push(callback);
 
     if (this.inFlightFlush) {
+      this.logger.debug('skipping flush, there is an in flight flush');
       return await this.inFlightFlush;
     }
 
     this.inFlightFlush = this.executeFlush();
-    return await this.inFlightFlush;
+    const flushResponse = await this.inFlightFlush;
+    this.logger.debug('resetting client flush state');
+    this.inFlightFlush = null;
+    this.finalMessageId = null;
+    this.logger.trace('===flushResponse===', flushResponse);
+    return flushResponse;
   }
 
   /**
@@ -307,12 +316,9 @@ export default class Analytics {
    * this checks for pending flushes and executes them. All data is rolled up into a single FlushResponse.
    */
   private async executeFlush(flushedItems: MessageAndCallback[] = []): Promise<FlushResponse[]> {
-    // check if earlier flush was pushed to queue
-    this.logger.debug('in flush');
-
+    this.logger.debug('in execute flush');
     if (!this.enable) {
-      this.inFlightFlush = null;
-      this.finalMessageId = null;
+      this.logger.debug('client not enabled, skipping flush');
       this.flushResponses.splice(0, this.flushResponses.length);
       const nullResponse = this.nullFlushResponse();
       this.flushCallbacks
@@ -329,8 +335,6 @@ export default class Analytics {
 
     if (!this.queue.length) {
       this.logger.debug('queue is empty, nothing to flush');
-      this.inFlightFlush = null;
-      this.finalMessageId = null;
       this.flushResponses.splice(0, this.flushResponses.length);
       const nullResponse = this.nullFlushResponse();
       this.flushCallbacks
@@ -353,7 +357,7 @@ export default class Analytics {
 
       flushSize += itemSize;
       spliceIndex++;
-      if ((item.message.messageId ?? null) === this.finalMessageId) {
+      if ((item.message.messageId ?? null) === this.finalMessageId || !this.finalMessageId) {
         break; // guard against flushing items added to the message queue during this flush
       }
     }
@@ -376,8 +380,6 @@ export default class Analytics {
       this.flushCallbacks
         .splice(0, this.flushCallbacks.length)
         .map((callback) => setImmediate(callback, flushResponses));
-      this.inFlightFlush = null;
-      this.finalMessageId = null;
     };
 
     const data = {
@@ -421,7 +423,8 @@ export default class Analytics {
 
     this.flushResponses.push({ error, data });
     const finishedFlushing =
-      currentBatchOfMessages[currentBatchOfMessages.length - 1].messageId === this.finalMessageId;
+      currentBatchOfMessages[currentBatchOfMessages.length - 1].messageId === this.finalMessageId ||
+      !this.finalMessageId;
     if (finishedFlushing) {
       if (error) {
         done(error);


### PR DESCRIPTION
# Why
There was a bug where flushing an empty queue would clobber some flush state. This caused subsequent flushes to return an outdated `nullResponse`.

# How
- pulls some state up from executeFlush to flush to avoid clobbering state
- adds some more logs in for future debugging
- adds a test to ensure subsequent flushes after a nullFlushResponse do not return an old nullFlushResponse

# Test Plan
Added an automated test to catch this behavior in the future.